### PR TITLE
Handle queries with joined tables

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -23,16 +23,17 @@ func beforeQuery(scope *gorm.Scope) {
 			scope.Search.Where(fmt.Sprintf("%v.language_code = ?", quotedTableName), locale)
 		case "reverse":
 			if !scope.Search.Unscoped && hasDeletedAtColumn {
-				scope.Search.Where(fmt.Sprintf("(%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ? AND t2.deleted_at IS NULL) AND language_code = ?)", quotedPrimaryKey, quotedPrimaryKey, quotedTableName), locale, Global)
+				scope.Search.Where(fmt.Sprintf(
+					"(%v.%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ? AND t2.deleted_at IS NULL) AND %v.language_code = ?)", quotedTableName, quotedPrimaryKey, quotedPrimaryKey, quotedTableName, quotedTableName), locale, Global)
 			} else {
-				scope.Search.Where(fmt.Sprintf("(%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ?) AND language_code = ?)", quotedPrimaryKey, quotedPrimaryKey, quotedTableName), locale, Global)
+				scope.Search.Where(fmt.Sprintf("(%v.%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ?) AND %v.language_code = ?)", quotedTableName, quotedPrimaryKey, quotedPrimaryKey, quotedTableName, quotedTableName), locale, Global)
 			}
 		default:
 			if isLocale {
 				if !scope.Search.Unscoped && hasDeletedAtColumn {
-					scope.Search.Where(fmt.Sprintf("((%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ? AND t2.deleted_at IS NULL) AND language_code = ?) OR language_code = ?) AND deleted_at IS NULL", quotedPrimaryKey, quotedPrimaryKey, quotedTableName), locale, Global, locale)
+					scope.Search.Where(fmt.Sprintf("((%v.%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ? AND t2.deleted_at IS NULL) AND %v.language_code = ?) OR %v.language_code = ?) AND %v.deleted_at IS NULL", quotedTableName, quotedPrimaryKey, quotedPrimaryKey, quotedTableName, quotedTableName, quotedTableName, quotedTableName), locale, Global, locale)
 				} else {
-					scope.Search.Where(fmt.Sprintf("(%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ?) AND language_code = ?) OR (language_code = ?)", quotedPrimaryKey, quotedPrimaryKey, quotedTableName), locale, Global, locale)
+					scope.Search.Where(fmt.Sprintf("(%v.%v NOT IN (SELECT DISTINCT(%v) FROM %v t2 WHERE t2.language_code = ?) AND %v.language_code = ?) OR (%v.language_code = ?)", quotedTableName, quotedPrimaryKey, quotedPrimaryKey, quotedTableName, quotedTableName, quotedTableName), locale, Global, locale)
 				}
 			} else {
 				scope.Search.Where(fmt.Sprintf("%v.language_code = ?", quotedTableName), Global)

--- a/curd_test.go
+++ b/curd_test.go
@@ -129,6 +129,10 @@ func TestQuery(t *testing.T) {
 	if dbEN.Set("l10n:mode", "global").First(&productEN); productEN.LanguageCode != l10n.Global {
 		t.Error("Should find global product with global mode")
 	}
+
+	if dbEN.Joins("LEFT JOIN brands ON products.brand_id = brands.id").First(&productEN).Error != nil {
+		t.Error("Should handle queries with extra joins")
+	}
 }
 
 func TestDelete(t *testing.T) {

--- a/struct_test.go
+++ b/struct_test.go
@@ -15,6 +15,7 @@ type Product struct {
 	Name            string
 	DeletedAt       *time.Time
 	ColorVariations []ColorVariation
+	BrandID         uint `l10n:"sync"`
 	Brand           Brand
 	Tags            []Tag `gorm:"many2many:product_tags"`
 	l10n.Locale
@@ -53,9 +54,11 @@ func init() {
 	l10n.RegisterCallbacks(db)
 
 	db.DropTableIfExists(&Product{})
+	db.DropTableIfExists(&Brand{})
 	db.DropTableIfExists(&Tag{})
 	db.Exec("drop table product_tags;")
 	db.AutoMigrate(&Product{})
+	db.AutoMigrate(&Brand{})
 	db.AutoMigrate(&Tag{})
 
 	dbGlobal = db


### PR DESCRIPTION
When l10n modifies a query, it adds conditions on the primary key,
language_code and deleted_at, without specifying the table name.

If the query does a joins (to do an order by on a related table for
example), it can lead to ambiguous queries, because the column names
may exist in the joined tables.

This patch adds the needed table names in the modified query, so that
there is no more ambiguous column name.
